### PR TITLE
Remove hard requirement for installs to provide an executable path

### DIFF
--- a/app/src/frontend/attractmode/am-install.cpp
+++ b/app/src/frontend/attractmode/am-install.cpp
@@ -7,9 +7,10 @@
 // Qx Includes
 #include <qx/windows/qx-filedetails.h>
 #include <qx/core/qx-regularexpression.h>
+#include <qx/core/qx-system.h>
 
 // Project Includes
-#include "../../clifp.h"
+#include "clifp.h"
 
 namespace Am
 {
@@ -117,8 +118,6 @@ Qx::Error Install::populateExistingDocs()
     // Return success
     return Qx::Error();
 }
-
-QString Install::executableSubPath() const { return MAIN_EXE_PATH; }
 
 QString Install::imageDestinationPath(Fp::ImageType imageType, const Fe::Game* game) const
 {
@@ -294,6 +293,11 @@ void Install::softReset()
 
 QString Install::name() const { return NAME; }
 QList<Fe::ImageMode> Install::preferredImageModeOrder() const { return IMAGE_MODE_ORDER; }
+
+bool Install::isRunning() const
+{
+    return Qx::processIsRunning(mMainExe.fileName()) || Qx::processIsRunning(mConsoleExe.fileName());
+}
 
 QString Install::versionString() const
 {

--- a/app/src/frontend/attractmode/am-install.h
+++ b/app/src/frontend/attractmode/am-install.h
@@ -91,9 +91,6 @@ private:
     void nullify() override;
     Qx::Error populateExistingDocs() override;
 
-    // Info
-    QString executableSubPath() const override;
-
     // Image Processing
     QString imageDestinationPath(Fp::ImageType imageType, const Fe::Game* game) const;
 
@@ -117,6 +114,7 @@ public:
     // Info
     QString name() const override;
     QList<Fe::ImageMode> preferredImageModeOrder() const override;
+    bool isRunning() const override;
     QString versionString() const override;
     QString translateDocName(const QString& originalName, Fe::DataDoc::Type type) const override;
 

--- a/app/src/frontend/fe-install.cpp
+++ b/app/src/frontend/fe-install.cpp
@@ -4,9 +4,6 @@
 // Qt Includes
 #include <QFileInfo>
 
-// Qx Includes
-#include <qx/windows/qx-filedetails.h>
-
 namespace Fe
 {
 
@@ -61,20 +58,7 @@ void Install::softReset()
 
 bool Install::supportsImageMode(ImageMode imageMode) const { return preferredImageModeOrder().contains(imageMode); }
 
-QString Install::versionString() const
-{
-    Qx::FileDetails exeDetails = Qx::FileDetails::readFileDetails(executablePath());
-
-    QString fileVersionStr = exeDetails.stringTable().fileVersion;
-    QString productVersionStr = exeDetails.stringTable().productVersion;
-
-    if(!fileVersionStr.isEmpty())
-        return fileVersionStr;
-    else if(!productVersionStr.isEmpty())
-        return productVersionStr;
-    else
-        return u"Unknown Version"_s;
-}
+QString Install::versionString() const { return u"Unknown Version"_s; }
 
 /* These functions can be overridden by children as needed.
  * Work within them should be kept as minimal as possible since they are not accounted

--- a/app/src/frontend/fe-install.h
+++ b/app/src/frontend/fe-install.h
@@ -69,9 +69,6 @@ protected:
     virtual std::shared_ptr<PlatformDoc::Writer> preparePlatformDocCommit(const std::unique_ptr<PlatformDoc>& document) = 0;
     virtual std::shared_ptr<PlaylistDoc::Writer> preparePlaylistDocCommit(const std::unique_ptr<PlaylistDoc>& document) = 0;
 
-    // Info
-    virtual QString executableSubPath() const override = 0;
-
 public:
     // Install management
     virtual void softReset() override;
@@ -81,6 +78,7 @@ public:
     virtual QList<ImageMode> preferredImageModeOrder() const = 0;
     bool supportsImageMode(ImageMode imageMode) const;
     virtual QString versionString() const;
+    virtual bool isRunning() const = 0;
 
     // Import stage notifier hooks
     virtual Qx::Error preImport(const ImportDetails& details);

--- a/app/src/frontend/fe-installfoundation.cpp
+++ b/app/src/frontend/fe-installfoundation.cpp
@@ -226,15 +226,11 @@ Fe::DocHandlingError InstallFoundation::commitDataDocument(DataDoc* docToSave, s
 }
 
 QList<QString> InstallFoundation::modifiedPlatforms() const { return modifiedDataDocs(DataDoc::Type::Platform); }
-
 QList<QString> InstallFoundation::modifiedPlaylists() const { return modifiedDataDocs(DataDoc::Type::Playlist);}
 
 //Public:
 bool InstallFoundation::isValid() const { return mValid; }
 QString InstallFoundation::path() const { return mRootDirectory.absolutePath(); }
-
-QString InstallFoundation::executableName() const { return QFileInfo(executableSubPath()).fileName(); }
-QString InstallFoundation::executablePath() const { return mRootDirectory.absoluteFilePath(executableSubPath()); }
 
 Qx::Error InstallFoundation::refreshExistingDocs(bool* changed)
 {

--- a/app/src/frontend/fe-installfoundation.h
+++ b/app/src/frontend/fe-installfoundation.h
@@ -143,7 +143,6 @@ protected:
     virtual void softReset();
     void declareValid(bool valid);
     virtual Qx::Error populateExistingDocs() = 0; // Stated redundantly again in Install to make it clear its part of the main interface
-    virtual QString executableSubPath() const = 0; // Stated redundantly again in Install to make it clear its part of the main interface
 
     virtual QString translateDocName(const QString& originalName, DataDoc::Type type) const;
     void catalogueExistingDoc(DataDoc::Identifier existingDoc);
@@ -157,9 +156,6 @@ protected:
 public:
     bool isValid() const;
     QString path() const;
-
-    QString executableName() const;
-    QString executablePath() const;
 
     Qx::Error refreshExistingDocs(bool* changed = nullptr);
     bool containsPlatform(const QString& name) const;

--- a/app/src/frontend/launchbox/lb-install.cpp
+++ b/app/src/frontend/launchbox/lb-install.cpp
@@ -12,6 +12,7 @@
 #include <qx/io/qx-common-io.h>
 #include <qx/core/qx-json.h>
 #include <qx/core/qx-versionnumber.h>
+#include <qx/core/qx-system.h>
 #include <qx/windows/qx-filedetails.h>
 
 namespace Lb
@@ -23,18 +24,17 @@ namespace Lb
 //-Constructor------------------------------------------------------------------------------------------------
 //Public:
 Install::Install(const QString& installPath) :
-    Fe::Install(installPath)
-{
-    // Initialize files and directories;
-    mPlatformImagesDirectory = QDir(installPath + '/' + PLATFORM_IMAGES_PATH);
-    mPlatformIconsDirectory = QDir(installPath + '/' + PLATFORM_ICONS_PATH);
-    mPlaylistIconsDirectory = QDir(installPath + '/' + PLAYLIST_ICONS_PATH);
-    mPlatformCategoryIconsDirectory = QDir(installPath + '/' + PLATFORM_CATEGORY_ICONS_PATH);
-    mDataDirectory = QDir(installPath + '/' + DATA_PATH);
-    mCoreDirectory = QDir(installPath + '/' + CORE_PATH);
-    mPlatformsDirectory = QDir(installPath + '/' + PLATFORMS_PATH);
-    mPlaylistsDirectory = QDir(installPath + '/' + PLAYLISTS_PATH);
-
+    Fe::Install(installPath),
+    mDataDirectory(installPath + '/' + DATA_PATH),
+    mPlatformsDirectory(installPath + '/' + PLATFORMS_PATH),
+    mPlaylistsDirectory(installPath + '/' + PLAYLISTS_PATH),
+    mPlatformImagesDirectory(installPath + '/' + PLATFORM_IMAGES_PATH),
+    mPlatformIconsDirectory(installPath + '/' + PLATFORM_ICONS_PATH),
+    mPlatformCategoryIconsDirectory(installPath + '/' + PLATFORM_CATEGORY_ICONS_PATH),
+    mPlaylistIconsDirectory(installPath + '/' + PLAYLIST_ICONS_PATH),
+    mCoreDirectory(installPath + '/' + CORE_PATH),
+    mExeFile(installPath + '/' + MAIN_EXE_PATH)
+{    
     // Check validity
     QFileInfo mainExe(installPath + '/' + MAIN_EXE_PATH);
     if(!mainExe.exists() || !mainExe.isFile() || !mPlatformsDirectory.exists() || !mPlaylistsDirectory.exists())
@@ -94,8 +94,6 @@ Qx::Error Install::populateExistingDocs()
     // Return success
     return Qx::Error();
 }
-
-QString Install::executableSubPath() const { return MAIN_EXE_PATH; }
 
 QString Install::imageDestinationPath(Fp::ImageType imageType, const Fe::Game* game) const
 {
@@ -300,6 +298,22 @@ void Install::softReset()
 
 QString Install::name() const { return NAME; }
 QList<Fe::ImageMode> Install::preferredImageModeOrder() const { return IMAGE_MODE_ORDER; }
+bool Install::isRunning() const { return Qx::processIsRunning(mExeFile.fileName()); }
+
+QString Install::versionString() const
+{
+    Qx::FileDetails exeDetails = Qx::FileDetails::readFileDetails(mExeFile.fileName());
+
+    QString fileVersionStr = exeDetails.stringTable().fileVersion;
+    QString productVersionStr = exeDetails.stringTable().productVersion;
+
+    if(!fileVersionStr.isEmpty())
+        return fileVersionStr;
+    else if(!productVersionStr.isEmpty())
+        return productVersionStr;
+    else
+        return Install::versionString();
+}
 
 QString Install::translateDocName(const QString& originalName, Fe::DataDoc::Type type) const
 {

--- a/app/src/frontend/launchbox/lb-install.h
+++ b/app/src/frontend/launchbox/lb-install.h
@@ -70,6 +70,7 @@ private:
     QDir mPlatformCategoryIconsDirectory;
     QDir mPlaylistIconsDirectory;
     QDir mCoreDirectory;
+    QFileInfo mExeFile;
 
     // Image transfers for import worker
     QList<ImageMap> mWorkerImageJobs;
@@ -95,9 +96,6 @@ private:
     void nullify() override;
     Qx::Error populateExistingDocs() override;
 
-    // Info
-    QString executableSubPath() const override;
-
     // Image Processing
     QString imageDestinationPath(Fp::ImageType imageType, const Fe::Game* game) const;
     void editBulkImageReferences(const Fe::ImageSources& imageSources);
@@ -121,6 +119,8 @@ public:
     // Info
     QString name() const override;
     QList<Fe::ImageMode> preferredImageModeOrder() const override;
+    bool isRunning() const override;
+    QString versionString() const override;
     QString translateDocName(const QString& originalName, Fe::DataDoc::Type type) const override;
 
     // Import stage notifier hooks

--- a/app/src/mainwindow.cpp
+++ b/app/src/mainwindow.cpp
@@ -613,7 +613,7 @@ void MainWindow::prepareImport()
 
     // Only allow proceeding if frontend isn't running
     bool feRunning;
-    while((feRunning = Qx::processIsRunning(mFrontendInstall->executableName())))
+    while((feRunning = mFrontendInstall->isRunning()))
         if(QMessageBox::critical(this, QApplication::applicationName(), MSG_FRONTEND_CLOSE_PROMPT, QMessageBox::Retry | QMessageBox::Cancel, QMessageBox::Retry) == QMessageBox::Cancel)
             break;
 


### PR DESCRIPTION
Adds other pure virtual functions that take over its previous purpose, which also allows for installs to have finer control over this info.